### PR TITLE
Add neutral fields for multichice

### DIFF
--- a/imports/client/ui/tasks/MultiChoiceView.js
+++ b/imports/client/ui/tasks/MultiChoiceView.js
@@ -26,9 +26,13 @@ export default class MultiChoiceView extends Component {
       let result = this.state.result;
       let solvedPercentage = null;
       if (this.state.totalAnswerCount > 0) {
-        solvedPercentage = this.state.falseCount / this.state.totalAnswerCount;
+        solvedPercentage =
+          (this.state.totalAnswerCount - this.state.falseCount) /
+          this.state.totalAnswerCount;
       } else {
-        solvedPercentage = result.falseCount / result.totalAnswerCount;
+        solvedPercentage =
+          (result.totalAnswerCount - result.falseCount) /
+          result.totalAnswerCount;
       }
       const { currentTraining } = this.props.student;
       Meteor.call(
@@ -218,14 +222,21 @@ export default class MultiChoiceView extends Component {
         return element.id.toString() === questionId.toString();
       });
       if (falseQuestion) {
-        correctAnswers = falseQuestion.sol;
+        correctAnswers = falseQuestion.correct;
       }
     }
 
     return set.map((answer, index) => {
       let color = "";
       if (this.state.showSolution && correctAnswers.length > 0) {
-        color = correctAnswers.includes(answer) ? "green" : "red";
+        if (
+          this.state.result.neutralAnswers !== undefined &&
+          this.state.result.neutralAnswers.includes(answer)
+        ) {
+          color = "yellow";
+        } else {
+          color = correctAnswers.includes(answer) ? "green" : "red";
+        }
       }
       return (
         <Checkbox

--- a/private/solutions.json
+++ b/private/solutions.json
@@ -49,22 +49,21 @@
   "Ziele": ["Zielsetzungstheorie", "Locke", "Moderatoren"],
   "ZieleCloze": ["Zielsetzungstheorie", "Locke", "Moderatoren"],
   "XwertCloze": ["5", "0", "0", "3", "3,75", "-0,875"],
-  "XWertMulti": [{ "id": 1, "sol": ["Lisa (M = 5)"] }],
-  "MultiWhy": [{ "id": 1, "sol": ["free"] }],
+  "XWertMulti": [{ "id": 1, "correct": ["Lisa (M = 5)"] }],
+  "MultiWhy": [{ "id": 1, "correct": ["free"] }],
   "MultiExtrIntr": [
     {
-      "id": 2,
-      "sol": [
+      "id": 1,
+      "correct": [
         "Intrinsische Motivation bedeutet, dass die Motivation von innen heraus kommt, zum Beispiel durch Interesse",
         "Der Korrumpierungseffekt kann auch als „Undermining Effekt“ bezeichnet werden"
       ]
     }
   ],
-
   "MultiOutro": [
     {
       "id": 3,
-      "sol": [
+      "correct": [
         "Spezifisch",
         "Messbar",
         "Akzeptiert",
@@ -74,7 +73,7 @@
     },
     {
       "id": 4,
-      "sol": [
+      "correct": [
         "dadurch, dass du einen neuen Anreiz geschaffen hast ( Entlohnung für das Amt), ist ein Korrumpierungseffekt aufgetreten, indem Magdas intrinsische Motivation von dem externen Anreiz überlagert wurde",
         "Durch die Unterstützung, die du außerdem angeboten hast, fühlte sich Magda in ihrem Autonomieerleben eingeschränkt und war deswegen weniger intrinsisch motiviert",
         "Durch ihr Amt hat Magda sich ihren Klassenkameraden überlegen gefühlt, sodass ihr Bedürfnis nach sozialer Eingebundenheit nicht erfüllt war, dies wollte sie nun ändern"
@@ -82,7 +81,7 @@
     },
     {
       "id": 5,
-      "sol": [
+      "correct": [
         "Durch die Angst vor der Scheidung seiner Eltern und den möglichen Umzug ist das Sicherheitsbedürfnis und evtl. das Sozialbedürfnis von Tino nicht erfüllt gewesen und somit konnte er auch keine Motivation aufbringen, sich in dem Kunstprojekt selbst zu „verwirklichen“",
         "Durch die Angst (mögliche Scheidung der Eltern /  möglicher Umzug) wurde Kreativität und Motivation gehemmt"
       ]
@@ -91,7 +90,7 @@
   "Quests": [
     {
       "id": 1,
-      "sol": [
+      "correct": [
         "dadurch, dass du einen neuen Anreiz geschaffen hast ( Entlohnung für das Amt), ist ein Korrumpierungseffekt aufgetreten, indem Magdas intrinsische Motivation von dem externen Anreiz überlagert wurde",
         "Durch die Unterstützung, die du außerdem angeboten hast, fühlte sich Magda in ihrem Autonomieerleben eingeschränkt und war deswegen weniger intrinsisch motiviert",
         "Durch ihr Amt hat Magda sich ihren Klassenkameraden überlegen gefühlt, sodass ihr Bedürfnis nach sozialer Eingebundenheit nicht erfüllt war, dies wollte sie nun ändern"
@@ -99,7 +98,7 @@
     },
     {
       "id": 2,
-      "sol": [
+      "correct": [
         "Durch die Angst vor der Scheidung seiner Eltern und den möglichen Umzug ist das Sicherheitsbedürfnis und evtl. das Sozialbedürfnis von Tino nicht erfüllt gewesen und somit konnte er auch keine Motivation aufbringen, sich in dem Kunstprojekt selbst zu „verwirklichen“",
         "Durch die Angst (mögliche Scheidung der Eltern /  möglicher Umzug) wurde Kreativität und Motivation gehemmt"
       ]

--- a/private/tasks/motivation.json
+++ b/private/tasks/motivation.json
@@ -216,7 +216,7 @@
       "filePrefix": "Multi",
       "content": [
         {
-          "QuestionId": 2,
+          "QuestionId": 1,
           "Question": "Markiere alle richtigen Aussagen",
           "AnswerSet": [
             "Intrinsische Motivation bedeutet, dass die Motivation von innen heraus kommt, zum Beispiel durch Interesse",

--- a/server/solutionHandling.js
+++ b/server/solutionHandling.js
@@ -116,8 +116,8 @@ Meteor.methods({
     });
 
     // question has no "correct" answer
-    if (currentSolution.sol[0] === "free") {
-      return currentSolution.sol.concat(studentSolution);
+    if (currentSolution.correct[0] === "free") {
+      return currentSolution.correct.concat(studentSolution);
     }
 
     let retval = checkMulti(

--- a/server/solutionHandling/multiSolver.js
+++ b/server/solutionHandling/multiSolver.js
@@ -14,10 +14,15 @@ export function checkMulti(question, studentSolution, correctSolution) {
       studentSolution.length > 0
         ? studentSolution[0].values.includes(answers[i])
         : false;
-    let answerIsCorrect = correctSolution.sol.includes(answers[i]);
+    let answerIsCorrect = correctSolution.correct.includes(answers[i]);
 
     if (answerIsSelected != answerIsCorrect) {
-      falseCount++;
+      let answerNeutral =
+        correctSolution.neutral !== undefined &&
+        correctSolution.neutral.includes(answers[i]);
+      if (!answerNeutral) {
+        falseCount++;
+      }
     }
   }
   let falseQuestions = [];
@@ -28,6 +33,7 @@ export function checkMulti(question, studentSolution, correctSolution) {
   let retval = {
     falseCount,
     totalAnswerCount: answers.length,
+    neutralAnswers: correctSolution.neutral,
     falseQuestions
   };
 


### PR DESCRIPTION
Es kann nun in der solutions.json file bei den Multichoice solutions ein neutral array angegeben werden. Die Antworten im neutral array werden aus der Bewertung rausgenommen.

"BspMulti": 
[
  {
    "id": 1,
    "correct":
      [
        "Hier die korrekten Antworten"
      ],
    "neutral":
      [
        "Hier die neutralen Antworten"
      ]
  }
]

Bis jetzt ist diese Funktion zwar implementiert, aber noch in keinem Task eingepflegt.
