### PR TITLE
fix: tag renderer

### DIFF
--- a/imports/ui/taskRenderers/RenderTag.js
+++ b/imports/ui/taskRenderers/RenderTag.js
@@ -1,8 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react"
 import { parseContent, StaticTag } from "@xyng/yuoshi-backend-adapter";
 import { Button, Grid, Header, Image, Label, Segment } from "semantic-ui-react";
-import Hyphenated from "react-hyphen";
-import de from "hyphenated-de";
 import PromisifiedMeteor from "../../api/promisified";
 import Swal from "sweetalert2";
 
@@ -128,19 +126,19 @@ function RenderTagKeyword({ content, tags, foundTags, onClick }) {
         })
     }, [content, tags, foundTags])
 
-    return <Hyphenated language={de}>
+    return <div>
         {parts.map((part, index) => {
             return <React.Fragment key={`part-${part.id}-${index}`}>
                 <span>{part.content}</span>
-                <RenderTagItem
+                {part.tag && <RenderTagItem
                     onClick={onClick(part.id)}
                     found={part.found}
                 >
                     {part.tag}
-                </RenderTagItem>
+                </RenderTagItem>}
             </React.Fragment>
         })}
-    </Hyphenated>
+    </div>
 }
 
 function RenderTagItem({ found, onClick, children }) {

--- a/imports/ui/taskRenderers/RenderTag.js
+++ b/imports/ui/taskRenderers/RenderTag.js
@@ -111,7 +111,7 @@ function RenderTagKeyword({ content, tags, foundTags, onClick }) {
     const parts = useMemo(() => {
         return parseContent(
             content,
-            "\\s",
+            "\\b",
             `${tags.map(tag => tag.tag).join("|")}`
         ).map((part, index) => {
             let tag_id = part.id ? tags.find(tag => tag.tag === part.id.trim()) : undefined


### PR DESCRIPTION
Löst folgende Probleme mit dem Tag-Renderer:
1. Es wird nun kein Fehler mehr durch `react-hyphen` verursacht. Das Paket kommt mit den Children-Arrays die durch das verwendete `parts.map(...)` entstehen nicht klar
2. Keywords, die nicht zwischen zwei Spaces sind, werden nun auch erkannt (Sprich: wenn sie am Anfang oder Ende einer Zeile, bzw. am Ende eines Satzes stehen, werden sie nun auch erkannt)