### PR TITLE
swal prevent outside click

### DIFF
--- a/imports/ui/taskRenderers/RenderDrag.js
+++ b/imports/ui/taskRenderers/RenderDrag.js
@@ -255,7 +255,8 @@ function RenderDrag(props) {
       confirmButtonText: "Lösung zeigen",
       cancelButtonText: "Nochmal versuchen",
       cancelButtonColor: "#3085d6",
-      showCancelButton: true
+      showCancelButton: true,
+      allowOutsideClick: false
     });
 
     if (showSolution) {


### PR DESCRIPTION
add allowOutsideClick: false to all current swal popups where the tim…er is not set

currently only happening in one instance (RenderDrag) and needs to be done when we implement the swal popup for "Lösung anzeigen" in the other TaskRenderers.