### PR TITLE
add linespace css for intro texts to seperate hobbies from description

### DIFF
--- a/imports/ui/taskRenderers/RenderIntro.scss
+++ b/imports/ui/taskRenderers/RenderIntro.scss
@@ -110,7 +110,7 @@
   
   font-size: 12px;
   line-height: 15px;
-
+  white-space: pre-line;
   letter-spacing: 0px;
   color: #000000;
   opacity: 1;


### PR DESCRIPTION
im intro werden jetzt die hobbies von der personenbeschreibung getrennt, wenn diese auch im studip plugin durch einen absatz getrennt sind

this closes #428 